### PR TITLE
perf: Bypass reflect for map operations

### DIFF
--- a/bench/easyjsongen/easyjsongen.go
+++ b/bench/easyjsongen/easyjsongen.go
@@ -26,6 +26,10 @@ type MapStringString struct {
 	Data map[string]string `json:"data"`
 }
 
+type MapIntMapStringStruct3 struct {
+	Data map[int]map[string]Struct3 `json:"data"`
+}
+
 type Struct3 struct {
 	Name   string   `json:"name"`
 	Number int      `json:"number"`

--- a/bench/easyjsongen/easyjsongen_easyjson.go
+++ b/bench/easyjsongen/easyjsongen_easyjson.go
@@ -481,7 +481,133 @@ func (v *MapStringString) UnmarshalJSON(data []byte) error {
 func (v *MapStringString) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen4(l, v)
 }
-func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(in *jlexer.Lexer, out *IntArray) {
+func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(in *jlexer.Lexer, out *MapIntMapStringStruct3) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "data":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				in.Delim('{')
+				out.Data = make(map[int]map[string]Struct3)
+				for !in.IsDelim('}') {
+					key := int(in.IntStr())
+					in.WantColon()
+					var v9 map[string]Struct3
+					if in.IsNull() {
+						in.Skip()
+					} else {
+						in.Delim('{')
+						v9 = make(map[string]Struct3)
+						for !in.IsDelim('}') {
+							key := string(in.String())
+							in.WantColon()
+							var v10 Struct3
+							(v10).UnmarshalEasyJSON(in)
+							(v9)[key] = v10
+							in.WantComma()
+						}
+						in.Delim('}')
+					}
+					(out.Data)[key] = v9
+					in.WantComma()
+				}
+				in.Delim('}')
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(out *jwriter.Writer, in MapIntMapStringStruct3) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"data\":"
+		out.RawString(prefix[1:])
+		if in.Data == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
+			out.RawString(`null`)
+		} else {
+			out.RawByte('{')
+			v11First := true
+			for v11Name, v11Value := range in.Data {
+				if v11First {
+					v11First = false
+				} else {
+					out.RawByte(',')
+				}
+				out.IntStr(int(v11Name))
+				out.RawByte(':')
+				if v11Value == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
+					out.RawString(`null`)
+				} else {
+					out.RawByte('{')
+					v12First := true
+					for v12Name, v12Value := range v11Value {
+						if v12First {
+							v12First = false
+						} else {
+							out.RawByte(',')
+						}
+						out.String(string(v12Name))
+						out.RawByte(':')
+						(v12Value).MarshalEasyJSON(out)
+					}
+					out.RawByte('}')
+				}
+			}
+			out.RawByte('}')
+		}
+	}
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v MapIntMapStringStruct3) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v MapIntMapStringStruct3) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *MapIntMapStringStruct3) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *MapIntMapStringStruct3) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(l, v)
+}
+func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(in *jlexer.Lexer, out *IntArray) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -516,9 +642,9 @@ func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjson
 					out.Data = (out.Data)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v9 int
-					v9 = int(in.Int())
-					out.Data = append(out.Data, v9)
+					var v13 int
+					v13 = int(in.Int())
+					out.Data = append(out.Data, v13)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -533,7 +659,7 @@ func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjson
 		in.Consumed()
 	}
 }
-func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(out *jwriter.Writer, in IntArray) {
+func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(out *jwriter.Writer, in IntArray) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -544,11 +670,11 @@ func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjson
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v10, v11 := range in.Data {
-				if v10 > 0 {
+			for v14, v15 := range in.Data {
+				if v14 > 0 {
 					out.RawByte(',')
 				}
-				out.Int(int(v11))
+				out.Int(int(v15))
 			}
 			out.RawByte(']')
 		}
@@ -559,27 +685,27 @@ func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjson
 // MarshalJSON supports json.Marshaler interface
 func (v IntArray) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(&w, v)
+	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v IntArray) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(w, v)
+	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *IntArray) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(&r, v)
+	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *IntArray) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen5(l, v)
+	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(l, v)
 }
-func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(in *jlexer.Lexer, out *BoolMatrix) {
+func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(in *jlexer.Lexer, out *BoolMatrix) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -614,30 +740,30 @@ func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjson
 					out.Data = (out.Data)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v12 []bool
+					var v16 []bool
 					if in.IsNull() {
 						in.Skip()
-						v12 = nil
+						v16 = nil
 					} else {
 						in.Delim('[')
-						if v12 == nil {
+						if v16 == nil {
 							if !in.IsDelim(']') {
-								v12 = make([]bool, 0, 64)
+								v16 = make([]bool, 0, 64)
 							} else {
-								v12 = []bool{}
+								v16 = []bool{}
 							}
 						} else {
-							v12 = (v12)[:0]
+							v16 = (v16)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v13 bool
-							v13 = bool(in.Bool())
-							v12 = append(v12, v13)
+							var v17 bool
+							v17 = bool(in.Bool())
+							v16 = append(v16, v17)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					out.Data = append(out.Data, v12)
+					out.Data = append(out.Data, v16)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -652,7 +778,7 @@ func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjson
 		in.Consumed()
 	}
 }
-func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(out *jwriter.Writer, in BoolMatrix) {
+func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(out *jwriter.Writer, in BoolMatrix) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -663,19 +789,19 @@ func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjson
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v14, v15 := range in.Data {
-				if v14 > 0 {
+			for v18, v19 := range in.Data {
+				if v18 > 0 {
 					out.RawByte(',')
 				}
-				if v15 == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v19 == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v16, v17 := range v15 {
-						if v16 > 0 {
+					for v20, v21 := range v19 {
+						if v20 > 0 {
 							out.RawByte(',')
 						}
-						out.Bool(bool(v17))
+						out.Bool(bool(v21))
 					}
 					out.RawByte(']')
 				}
@@ -689,27 +815,27 @@ func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjson
 // MarshalJSON supports json.Marshaler interface
 func (v BoolMatrix) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(&w, v)
+	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BoolMatrix) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(w, v)
+	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *BoolMatrix) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(&r, v)
+	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BoolMatrix) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen6(l, v)
+	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(l, v)
 }
-func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(in *jlexer.Lexer, out *Any) {
+func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen8(in *jlexer.Lexer, out *Any) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -746,7 +872,7 @@ func easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjson
 		in.Consumed()
 	}
 }
-func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(out *jwriter.Writer, in Any) {
+func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen8(out *jwriter.Writer, in Any) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -767,23 +893,23 @@ func easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjson
 // MarshalJSON supports json.Marshaler interface
 func (v Any) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(&w, v)
+	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen8(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Any) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(w, v)
+	easyjson64a62fcEncodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen8(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Any) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(&r, v)
+	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen8(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Any) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen7(l, v)
+	easyjson64a62fcDecodeGithubComRomsharkJscanExperimentalDecoderBenchEasyjsongen8(l, v)
 }

--- a/bench/ffjsongen/ffjsongen.go
+++ b/bench/ffjsongen/ffjsongen.go
@@ -26,6 +26,15 @@ type MapStringString struct {
 	Data map[string]string `json:"data"`
 }
 
+type MapIntMapStringStruct3 struct {
+	// Can't use Struct3 because it fails the code generator
+	Data map[int]map[string]struct {
+		Name   string   `json:"name"`
+		Number int      `json:"number"`
+		Tags   []string `json:"tags"`
+	} `json:"data"`
+}
+
 type Struct3 struct {
 	Name   string   `json:"name"`
 	Number int      `json:"number"`

--- a/bench/ffjsongen/ffjsongen_ffjson.go
+++ b/bench/ffjsongen/ffjsongen_ffjson.go
@@ -674,6 +674,376 @@ done:
 }
 
 // MarshalJSON marshal bytes to json - template
+func (j *MapIntMapStringStruct3) MarshalJSON() ([]byte, error) {
+	var buf fflib.Buffer
+	if j == nil {
+		buf.WriteString("null")
+		return buf.Bytes(), nil
+	}
+	err := j.MarshalJSONBuf(&buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// MarshalJSONBuf marshal buff to json - template
+func (j *MapIntMapStringStruct3) MarshalJSONBuf(buf fflib.EncodingBuffer) error {
+	if j == nil {
+		buf.WriteString("null")
+		return nil
+	}
+	var err error
+	var obj []byte
+	_ = obj
+	_ = err
+	/* Falling back. type=map[int]map[string]struct { Name string "json:\"name\""; Number int "json:\"number\""; Tags []string "json:\"tags\"" } kind=map */
+	buf.WriteString(`{"data":`)
+	err = buf.Encode(j.Data)
+	if err != nil {
+		return err
+	}
+	buf.WriteByte('}')
+	return nil
+}
+
+const (
+	ffjtMapIntMapStringStruct3base = iota
+	ffjtMapIntMapStringStruct3nosuchkey
+
+	ffjtMapIntMapStringStruct3Data
+)
+
+var ffjKeyMapIntMapStringStruct3Data = []byte("data")
+
+// UnmarshalJSON umarshall json - template of ffjson
+func (j *MapIntMapStringStruct3) UnmarshalJSON(input []byte) error {
+	fs := fflib.NewFFLexer(input)
+	return j.UnmarshalJSONFFLexer(fs, fflib.FFParse_map_start)
+}
+
+// UnmarshalJSONFFLexer fast json unmarshall - template ffjson
+func (j *MapIntMapStringStruct3) UnmarshalJSONFFLexer(fs *fflib.FFLexer, state fflib.FFParseState) error {
+	var err error
+	currentKey := ffjtMapIntMapStringStruct3base
+	_ = currentKey
+	tok := fflib.FFTok_init
+	wantedTok := fflib.FFTok_init
+
+mainparse:
+	for {
+		tok = fs.Scan()
+		//	println(fmt.Sprintf("debug: tok: %v  state: %v", tok, state))
+		if tok == fflib.FFTok_error {
+			goto tokerror
+		}
+
+		switch state {
+
+		case fflib.FFParse_map_start:
+			if tok != fflib.FFTok_left_bracket {
+				wantedTok = fflib.FFTok_left_bracket
+				goto wrongtokenerror
+			}
+			state = fflib.FFParse_want_key
+			continue
+
+		case fflib.FFParse_after_value:
+			if tok == fflib.FFTok_comma {
+				state = fflib.FFParse_want_key
+			} else if tok == fflib.FFTok_right_bracket {
+				goto done
+			} else {
+				wantedTok = fflib.FFTok_comma
+				goto wrongtokenerror
+			}
+
+		case fflib.FFParse_want_key:
+			// json {} ended. goto exit. woo.
+			if tok == fflib.FFTok_right_bracket {
+				goto done
+			}
+			if tok != fflib.FFTok_string {
+				wantedTok = fflib.FFTok_string
+				goto wrongtokenerror
+			}
+
+			kn := fs.Output.Bytes()
+			if len(kn) <= 0 {
+				// "" case. hrm.
+				currentKey = ffjtMapIntMapStringStruct3nosuchkey
+				state = fflib.FFParse_want_colon
+				goto mainparse
+			} else {
+				switch kn[0] {
+
+				case 'd':
+
+					if bytes.Equal(ffjKeyMapIntMapStringStruct3Data, kn) {
+						currentKey = ffjtMapIntMapStringStruct3Data
+						state = fflib.FFParse_want_colon
+						goto mainparse
+					}
+
+				}
+
+				if fflib.SimpleLetterEqualFold(ffjKeyMapIntMapStringStruct3Data, kn) {
+					currentKey = ffjtMapIntMapStringStruct3Data
+					state = fflib.FFParse_want_colon
+					goto mainparse
+				}
+
+				currentKey = ffjtMapIntMapStringStruct3nosuchkey
+				state = fflib.FFParse_want_colon
+				goto mainparse
+			}
+
+		case fflib.FFParse_want_colon:
+			if tok != fflib.FFTok_colon {
+				wantedTok = fflib.FFTok_colon
+				goto wrongtokenerror
+			}
+			state = fflib.FFParse_want_value
+			continue
+		case fflib.FFParse_want_value:
+
+			if tok == fflib.FFTok_left_brace || tok == fflib.FFTok_left_bracket || tok == fflib.FFTok_integer || tok == fflib.FFTok_double || tok == fflib.FFTok_string || tok == fflib.FFTok_bool || tok == fflib.FFTok_null {
+				switch currentKey {
+
+				case ffjtMapIntMapStringStruct3Data:
+					goto handle_Data
+
+				case ffjtMapIntMapStringStruct3nosuchkey:
+					err = fs.SkipField(tok)
+					if err != nil {
+						return fs.WrapErr(err)
+					}
+					state = fflib.FFParse_after_value
+					goto mainparse
+				}
+			} else {
+				goto wantedvalue
+			}
+		}
+	}
+
+handle_Data:
+
+	/* handler: j.Data type=map[int]map[string]struct { Name string "json:\"name\""; Number int "json:\"number\""; Tags []string "json:\"tags\"" } kind=map quoted=false*/
+
+	{
+
+		{
+			if tok != fflib.FFTok_left_bracket && tok != fflib.FFTok_null {
+				return fs.WrapErr(fmt.Errorf("cannot unmarshal %s into Go value for ", tok))
+			}
+		}
+
+		if tok == fflib.FFTok_null {
+			j.Data = nil
+		} else {
+
+			j.Data = make(map[int]map[string]struct {
+				Name   string   "json:\"name\""
+				Number int      "json:\"number\""
+				Tags   []string "json:\"tags\""
+			}, 0)
+
+			wantVal := true
+
+			for {
+
+				var k int
+
+				var tmpJData map[string]struct {
+					Name   string   "json:\"name\""
+					Number int      "json:\"number\""
+					Tags   []string "json:\"tags\""
+				}
+
+				tok = fs.Scan()
+				if tok == fflib.FFTok_error {
+					goto tokerror
+				}
+				if tok == fflib.FFTok_right_bracket {
+					break
+				}
+
+				if tok == fflib.FFTok_comma {
+					if wantVal == true {
+						// TODO(pquerna): this isn't an ideal error message, this handles
+						// things like [,,,] as an array value.
+						return fs.WrapErr(fmt.Errorf("wanted value token, but got token: %v", tok))
+					}
+					continue
+				} else {
+					wantVal = true
+				}
+
+				/* handler: k type=int kind=int quoted=false*/
+
+				{
+					if tok != fflib.FFTok_integer && tok != fflib.FFTok_null {
+						return fs.WrapErr(fmt.Errorf("cannot unmarshal %s into Go value for int", tok))
+					}
+				}
+
+				{
+
+					if tok == fflib.FFTok_null {
+
+					} else {
+
+						tval, err := fflib.ParseInt(fs.Output.Bytes(), 10, 64)
+
+						if err != nil {
+							return fs.WrapErr(err)
+						}
+
+						k = int(tval)
+
+					}
+				}
+
+				// Expect ':' after key
+				tok = fs.Scan()
+				if tok != fflib.FFTok_colon {
+					return fs.WrapErr(fmt.Errorf("wanted colon token, but got token: %v", tok))
+				}
+
+				tok = fs.Scan()
+				/* handler: tmpJData type=map[string]struct { Name string "json:\"name\""; Number int "json:\"number\""; Tags []string "json:\"tags\"" } kind=map quoted=false*/
+
+				{
+
+					{
+						if tok != fflib.FFTok_left_bracket && tok != fflib.FFTok_null {
+							return fs.WrapErr(fmt.Errorf("cannot unmarshal %s into Go value for ", tok))
+						}
+					}
+
+					if tok == fflib.FFTok_null {
+						tmpJData = nil
+					} else {
+
+						tmpJData = make(map[string]struct {
+							Name   string   "json:\"name\""
+							Number int      "json:\"number\""
+							Tags   []string "json:\"tags\""
+						}, 0)
+
+						wantVal := true
+
+						for {
+
+							var k string
+
+							var tmpTmpJData struct {
+								Name   string   "json:\"name\""
+								Number int      "json:\"number\""
+								Tags   []string "json:\"tags\""
+							}
+
+							tok = fs.Scan()
+							if tok == fflib.FFTok_error {
+								goto tokerror
+							}
+							if tok == fflib.FFTok_right_bracket {
+								break
+							}
+
+							if tok == fflib.FFTok_comma {
+								if wantVal == true {
+									// TODO(pquerna): this isn't an ideal error message, this handles
+									// things like [,,,] as an array value.
+									return fs.WrapErr(fmt.Errorf("wanted value token, but got token: %v", tok))
+								}
+								continue
+							} else {
+								wantVal = true
+							}
+
+							/* handler: k type=string kind=string quoted=false*/
+
+							{
+
+								{
+									if tok != fflib.FFTok_string && tok != fflib.FFTok_null {
+										return fs.WrapErr(fmt.Errorf("cannot unmarshal %s into Go value for string", tok))
+									}
+								}
+
+								if tok == fflib.FFTok_null {
+
+								} else {
+
+									outBuf := fs.Output.Bytes()
+
+									k = string(string(outBuf))
+
+								}
+							}
+
+							// Expect ':' after key
+							tok = fs.Scan()
+							if tok != fflib.FFTok_colon {
+								return fs.WrapErr(fmt.Errorf("wanted colon token, but got token: %v", tok))
+							}
+
+							tok = fs.Scan()
+							/* handler: tmpTmpJData type=struct { Name string "json:\"name\""; Number int "json:\"number\""; Tags []string "json:\"tags\"" } kind=struct quoted=false*/
+
+							{
+								/* Falling back. type=struct { Name string "json:\"name\""; Number int "json:\"number\""; Tags []string "json:\"tags\"" } kind=struct */
+								tbuf, err := fs.CaptureField(tok)
+								if err != nil {
+									return fs.WrapErr(err)
+								}
+
+								err = json.Unmarshal(tbuf, &tmpTmpJData)
+								if err != nil {
+									return fs.WrapErr(err)
+								}
+							}
+
+							tmpJData[k] = tmpTmpJData
+
+							wantVal = false
+						}
+
+					}
+				}
+
+				j.Data[k] = tmpJData
+
+				wantVal = false
+			}
+
+		}
+	}
+
+	state = fflib.FFParse_after_value
+	goto mainparse
+
+wantedvalue:
+	return fs.WrapErr(fmt.Errorf("wanted value token, but got token: %v", tok))
+wrongtokenerror:
+	return fs.WrapErr(fmt.Errorf("ffjson: wanted token: %v, but got token: %v output=%s", wantedTok, tok, fs.Output.String()))
+tokerror:
+	if fs.BigError != nil {
+		return fs.WrapErr(fs.BigError)
+	}
+	err = fs.Error.ToError()
+	if err != nil {
+		return fs.WrapErr(err)
+	}
+	panic("ffjson-generated: unreachable, please report bug.")
+done:
+
+	return nil
+}
+
+// MarshalJSON marshal bytes to json - template
 func (j *MapStringString) MarshalJSON() ([]byte, error) {
 	var buf fflib.Buffer
 	if j == nil {

--- a/jscandec.go
+++ b/jscandec.go
@@ -373,11 +373,8 @@ type stackFrame[S []byte | string] struct {
 	// LastMapKey is relevant to map frames only.
 	LastMapKey any
 
-	// MapValue is relevant to map frames only.
-	// MapValue is set at runtime and must be reset on every call to Decode
-	// to avoid keeping an unsafe.Pointer to the allocated map and allow the GC
-	// to clean it up if necessary.
-	MapValue reflect.Value
+	// MapType and MapValueType are relevant to map frames only.
+	MapType, MapValueType *typ
 
 	// Size defines the number of bytes the data would occupy in memory.
 	// Size caches reflect.Type.Size() for faster access.
@@ -409,6 +406,10 @@ type stackFrame[S []byte | string] struct {
 	// Same as Size, Type kind could be taken from reflect.Type but it's
 	// slower than storing it here.
 	Type ExpectType
+
+	// MapCanUseAssignFaststr is only relevant to map frames and indicates whether
+	// mapassign_faststr can be used instead of mapassign.
+	MapCanUseAssignFaststr bool
 }
 
 // noParentFrame uses math.MaxUint32 because the length of the decoder stack
@@ -736,10 +737,13 @@ func appendTypeToStack[S []byte | string](
 		stack = append(stack, stackFrame[S]{
 			// The map will be handled via reflect.Value
 			// hence the size is not t.Size().
-			Size:             t.Size(),
-			Type:             ExpectTypeMap,
-			ParentFrameIndex: noParentFrame,
-			RType:            t,
+			Size:                   t.Size(),
+			Type:                   ExpectTypeMap,
+			MapType:                getTyp(t),
+			MapValueType:           getTyp(t.Elem()),
+			MapCanUseAssignFaststr: canUseAssignFaststr(t),
+			ParentFrameIndex:       noParentFrame,
+			RType:                  t,
 		})
 		{
 			newAtIndex := len(stack)
@@ -1038,7 +1042,6 @@ func (d *Decoder[S, T]) Decode(s S, t *T, options *DecodeOptions) (err ErrorDeco
 	defer func() {
 		for i := range d.stackExp {
 			d.stackExp[i].Dest = nil
-			d.stackExp[i].MapValue = reflect.Value{}
 		}
 	}()
 
@@ -2627,15 +2630,10 @@ func (d *Decoder[S, T]) Decode(s S, t *T, options *DecodeOptions) (err ErrorDeco
 					p := unsafe.Pointer(
 						uintptr(d.stackExp[si].Dest) + d.stackExp[si].Offset,
 					)
-					if *(*map[any]any)(p) != nil {
-						d.stackExp[si].MapValue = reflect.NewAt(
-							d.stackExp[si].RType, p,
-						).Elem()
-					} else {
-						d.stackExp[si].MapValue = reflect.MakeMapWithSize(
-							d.stackExp[si].RType, tokens[ti].Elements,
+					if *(*unsafe.Pointer)(p) == nil {
+						*(*unsafe.Pointer)(p) = makemap(
+							d.stackExp[si].MapType, tokens[ti].Elements,
 						)
-						*(*unsafe.Pointer)(p) = d.stackExp[si].MapValue.UnsafePointer()
 					}
 					if tokens[ti].Elements == 0 {
 						ti += 2
@@ -2983,40 +2981,63 @@ func (d *Decoder[S, T]) Decode(s S, t *T, options *DecodeOptions) (err ErrorDeco
 				case ExpectTypeSlice:
 					d.stackExp[si].Offset += d.stackExp[si].Size
 				case ExpectTypeMap:
-					var valKey reflect.Value
+					var valKeyStr string
+					var pKey unsafe.Pointer
 					switch d.stackExp[siParent+1].Type {
 					case ExpectTypeStr:
-						valKey = reflect.ValueOf(d.stackExp[siParent].LastMapKey.(string))
+						k := d.stackExp[siParent].LastMapKey.(string)
+						pKey, valKeyStr = unsafe.Pointer(&k), k
 					case ExpectTypeTextUnmarshaler:
-						valKey = d.stackExp[siParent].LastMapKey.(reflect.Value).Elem()
+						k := d.stackExp[siParent].LastMapKey.(reflect.Value)
+						pKey = k.UnsafePointer()
 					case ExpectTypeInt:
-						valKey = reflect.ValueOf(d.stackExp[siParent].LastMapKey.(int))
+						k := d.stackExp[siParent].LastMapKey.(int)
+						pKey = unsafe.Pointer(&k)
 					case ExpectTypeInt8:
-						valKey = reflect.ValueOf(d.stackExp[siParent].LastMapKey.(int8))
+						k := d.stackExp[siParent].LastMapKey.(int8)
+						pKey = unsafe.Pointer(&k)
 					case ExpectTypeInt16:
-						valKey = reflect.ValueOf(d.stackExp[siParent].LastMapKey.(int16))
+						k := d.stackExp[siParent].LastMapKey.(int16)
+						pKey = unsafe.Pointer(&k)
 					case ExpectTypeInt32:
-						valKey = reflect.ValueOf(d.stackExp[siParent].LastMapKey.(int32))
+						k := d.stackExp[siParent].LastMapKey.(int32)
+						pKey = unsafe.Pointer(&k)
 					case ExpectTypeInt64:
-						valKey = reflect.ValueOf(d.stackExp[siParent].LastMapKey.(int64))
+						k := d.stackExp[siParent].LastMapKey.(int64)
+						pKey = unsafe.Pointer(&k)
 					case ExpectTypeUint:
-						valKey = reflect.ValueOf(d.stackExp[siParent].LastMapKey.(uint))
+						k := d.stackExp[siParent].LastMapKey.(uint)
+						pKey = unsafe.Pointer(&k)
 					case ExpectTypeUint8:
-						valKey = reflect.ValueOf(d.stackExp[siParent].LastMapKey.(uint8))
+						k := d.stackExp[siParent].LastMapKey.(uint8)
+						pKey = unsafe.Pointer(&k)
 					case ExpectTypeUint16:
-						valKey = reflect.ValueOf(d.stackExp[siParent].LastMapKey.(uint16))
+						k := d.stackExp[siParent].LastMapKey.(uint16)
+						pKey = unsafe.Pointer(&k)
 					case ExpectTypeUint32:
-						valKey = reflect.ValueOf(d.stackExp[siParent].LastMapKey.(uint32))
+						k := d.stackExp[siParent].LastMapKey.(uint32)
+						pKey = unsafe.Pointer(&k)
 					case ExpectTypeUint64:
-						valKey = reflect.ValueOf(d.stackExp[siParent].LastMapKey.(uint64))
+						k := d.stackExp[siParent].LastMapKey.(uint64)
+						pKey = unsafe.Pointer(&k)
 					}
-					// Add key-value pair to the map
-					d.stackExp[siParent].MapValue.SetMapIndex(
-						valKey,
-						reflect.NewAt(
-							d.stackExp[siParent].RType.Elem(), d.stackExp[si].Dest,
-						).Elem(),
+					pMap := unsafe.Pointer(
+						uintptr(d.stackExp[siParent].Dest) + d.stackExp[siParent].Offset,
 					)
+					pVal := unsafe.Pointer(
+						uintptr(d.stackExp[si].Dest) + d.stackExp[si].Offset,
+					)
+					typMap := d.stackExp[siParent].MapType
+					typVal := d.stackExp[siParent].MapValueType
+					// Add key-value pair to the map using faster assign if possible.
+					if d.stackExp[siParent].MapCanUseAssignFaststr {
+						mapV := mapassign_faststr(
+							typMap, *(*unsafe.Pointer)(pMap), valKeyStr,
+						)
+						typedmemmove(typVal, mapV, noescape(pVal))
+					} else {
+						mapassign(typMap, *(*unsafe.Pointer)(pMap), pKey, noescape(pVal))
+					}
 					fallthrough
 				case ExpectTypeStruct:
 					si = siParent
@@ -3202,3 +3223,37 @@ func decodeAny[S ~[]byte | ~string](
 // emptyStructAddr the address to an empty slice remains the same
 // throughout the life of the process.
 var emptyStructAddr = unsafe.Pointer(&struct{}{})
+
+//go:linkname noescape reflect.noescape
+func noescape(p unsafe.Pointer) unsafe.Pointer
+
+//go:linkname typedmemmove reflect.typedmemmove
+func typedmemmove(t *typ, dst, src unsafe.Pointer)
+
+//go:linkname makemap reflect.makemap
+func makemap(*typ, int) unsafe.Pointer
+
+//nolint:golint
+//go:linkname mapassign_faststr runtime.mapassign_faststr
+//go:noescape
+func mapassign_faststr(t *typ, m unsafe.Pointer, s string) unsafe.Pointer
+
+//go:linkname mapassign reflect.mapassign
+//go:noescape
+func mapassign(t *typ, m unsafe.Pointer, k, v unsafe.Pointer)
+
+// typ represents reflect.rtype for noescape trick
+type typ struct{}
+
+type emptyInterface struct {
+	_   *typ
+	ptr unsafe.Pointer
+}
+
+func getTyp(t reflect.Type) *typ {
+	return (*typ)(((*emptyInterface)(unsafe.Pointer(&t))).ptr)
+}
+
+func canUseAssignFaststr(mapType reflect.Type) bool {
+	return mapType.Elem().Size() <= 128 && mapType.Key().Kind() == reflect.String
+}

--- a/jscandec.go
+++ b/jscandec.go
@@ -2669,8 +2669,9 @@ func (d *Decoder[S, T]) Decode(s S, t *T, options *DecodeOptions) (err ErrorDeco
 					tiEnd := tokens[ti].End
 
 					for ti++; ti < tiEnd; ti += 2 {
-						if tokens[ti+1].Type != jscan.TokenTypeString {
-							if tokens[ti+1].Type == jscan.TokenTypeNull {
+						tokVal := tokens[ti+1]
+						if tokVal.Type != jscan.TokenTypeString {
+							if tokVal.Type == jscan.TokenTypeNull {
 								key := s[tokens[ti].Index+1 : tokens[ti].End-1]
 								keyUnescaped := unescape.Valid[S, string](key)
 								m[keyUnescaped] = ""
@@ -2678,13 +2679,13 @@ func (d *Decoder[S, T]) Decode(s S, t *T, options *DecodeOptions) (err ErrorDeco
 							}
 							err = ErrorDecode{
 								Err:   ErrUnexpectedValue,
-								Index: tokens[ti+1].Index,
+								Index: tokVal.Index,
 							}
 							return true
 						}
 						key := s[tokens[ti].Index+1 : tokens[ti].End-1]
 						keyUnescaped := unescape.Valid[S, string](key)
-						value := s[tokens[ti+1].Index+1 : tokens[ti+1].End-1]
+						value := s[tokVal.Index+1 : tokVal.End-1]
 						m[keyUnescaped] = unescape.Valid[S, string](value)
 					}
 					ti++

--- a/jscandec_internal_test.go
+++ b/jscandec_internal_test.go
@@ -429,16 +429,6 @@ func TestAppendTypeToStack(t *testing.T) {
 					Size:             reflect.TypeOf(map[string]string{}).Size(),
 					ParentFrameIndex: noParentFrame,
 				},
-				{
-					Type:             ExpectTypeStr,
-					Size:             reflect.TypeOf(string("")).Size(),
-					ParentFrameIndex: 0,
-				},
-				{
-					Type:             ExpectTypeStr,
-					Size:             reflect.TypeOf(string("")).Size(),
-					ParentFrameIndex: 0,
-				},
 			},
 		},
 		{

--- a/jscandec_internal_test.go
+++ b/jscandec_internal_test.go
@@ -424,22 +424,19 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[string]string{},
 			ExpectStack: []stackFrame[string]{
 				{
-					RType:                  reflect.TypeOf(map[string]string{}),
-					Size:                   reflect.TypeOf(map[string]string{}).Size(),
-					Type:                   ExpectTypeMap,
-					MapType:                getTyp(reflect.TypeOf(map[string]string{})),
-					MapValueType:           getTyp(reflect.TypeOf(string(""))),
-					MapCanUseAssignFaststr: true,
-					ParentFrameIndex:       noParentFrame,
+					Type:             ExpectTypeMapStringString,
+					RType:            reflect.TypeOf(map[string]string{}),
+					Size:             reflect.TypeOf(map[string]string{}).Size(),
+					ParentFrameIndex: noParentFrame,
 				},
-				{ // Key frame
-					Size:             reflect.TypeOf(string("")).Size(),
+				{
 					Type:             ExpectTypeStr,
+					Size:             reflect.TypeOf(string("")).Size(),
 					ParentFrameIndex: 0,
 				},
-				{ // Value frame
-					Size:             reflect.TypeOf(string("")).Size(),
+				{
 					Type:             ExpectTypeStr,
+					Size:             reflect.TypeOf(string("")).Size(),
 					ParentFrameIndex: 0,
 				},
 			},
@@ -465,8 +462,8 @@ func TestAppendTypeToStack(t *testing.T) {
 					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key frame
-					Size:             reflect.TypeOf(string("")).Size(),
 					Type:             ExpectTypeStr,
+					Size:             reflect.TypeOf(string("")).Size(),
 					ParentFrameIndex: 0,
 				},
 				{ // Value frame

--- a/jscandec_internal_test.go
+++ b/jscandec_internal_test.go
@@ -424,10 +424,13 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[string]string{},
 			ExpectStack: []stackFrame[string]{
 				{
-					RType:            reflect.TypeOf(map[string]string{}),
-					Size:             reflect.TypeOf(map[string]string{}).Size(),
-					Type:             ExpectTypeMap,
-					ParentFrameIndex: noParentFrame,
+					RType:                  reflect.TypeOf(map[string]string{}),
+					Size:                   reflect.TypeOf(map[string]string{}).Size(),
+					Type:                   ExpectTypeMap,
+					MapType:                getTyp(reflect.TypeOf(map[string]string{})),
+					MapValueType:           getTyp(reflect.TypeOf(string(""))),
+					MapCanUseAssignFaststr: true,
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key frame
 					Size:             reflect.TypeOf(string("")).Size(),
@@ -442,13 +445,64 @@ func TestAppendTypeToStack(t *testing.T) {
 			},
 		},
 		{
+			Input: map[string]struct{ F [256]byte }{},
+			ExpectStack: []stackFrame[string]{
+				{
+					Type: ExpectTypeMap,
+					RType: reflect.TypeOf(
+						map[string]struct{ F [256]byte }{},
+					),
+					Size: reflect.TypeOf(
+						map[string]struct{ F [256]byte }{},
+					).Size(),
+					MapType: getTyp(
+						reflect.TypeOf(map[string]struct{ F [256]byte }{}),
+					),
+					MapValueType: getTyp(
+						reflect.TypeOf(struct{ F [256]byte }{}),
+					),
+					MapCanUseAssignFaststr: false, // Value too big
+					ParentFrameIndex:       noParentFrame,
+				},
+				{ // Key frame
+					Size:             reflect.TypeOf(string("")).Size(),
+					Type:             ExpectTypeStr,
+					ParentFrameIndex: 0,
+				},
+				{ // Value frame
+					Type: ExpectTypeStruct,
+					Size: reflect.TypeOf(struct{ F [256]byte }{}).Size(),
+					Fields: []fieldStackFrame{
+						{FrameIndex: 3, Name: "F"},
+					},
+					ParentFrameIndex: 0,
+				},
+				{ // Value frame
+					Type:             ExpectTypeArray,
+					Size:             reflect.TypeOf([256]byte{}).Size(),
+					ParentFrameIndex: 2,
+				},
+				{ // Value frame
+					Type:             ExpectTypeUint8,
+					Size:             reflect.TypeOf(byte(0)).Size(),
+					Cap:              256,
+					ParentFrameIndex: 3,
+				},
+			},
+		},
+		{
 			Input: map[testImplTextUnmarshaler]int{},
 			ExpectStack: []stackFrame[string]{
 				{
-					RType:            reflect.TypeOf(map[testImplTextUnmarshaler]int{}),
-					Type:             ExpectTypeMap,
-					Size:             reflect.TypeOf(map[testImplTextUnmarshaler]int{}).Size(),
-					ParentFrameIndex: noParentFrame,
+					RType: reflect.TypeOf(map[testImplTextUnmarshaler]int{}),
+					Type:  ExpectTypeMap,
+					Size:  reflect.TypeOf(map[testImplTextUnmarshaler]int{}).Size(),
+					MapType: getTyp(
+						reflect.TypeOf(map[testImplTextUnmarshaler]string{}),
+					),
+					MapValueType:           getTyp(reflect.TypeOf(string(""))),
+					MapCanUseAssignFaststr: false, // Key not a string
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key
 					RType:            reflect.TypeOf(testImplTextUnmarshaler{}),
@@ -467,10 +521,13 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[int]S1{},
 			ExpectStack: []stackFrame[string]{
 				{
-					RType:            reflect.TypeOf(map[int]S1{}),
-					Size:             reflect.TypeOf(map[int]S1{}).Size(),
-					Type:             ExpectTypeMap,
-					ParentFrameIndex: noParentFrame,
+					RType:                  reflect.TypeOf(map[int]S1{}),
+					Size:                   reflect.TypeOf(map[int]S1{}).Size(),
+					MapType:                getTyp(reflect.TypeOf(map[int]S1{})),
+					MapValueType:           getTyp(reflect.TypeOf(S1{})),
+					MapCanUseAssignFaststr: false, // Non-string key type
+					Type:                   ExpectTypeMap,
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key frame
 					Size:             reflect.TypeOf(int(0)).Size(),
@@ -505,6 +562,13 @@ func TestAppendTypeToStack(t *testing.T) {
 				{
 					Type:  ExpectTypeMap,
 					RType: reflect.TypeOf(map[int]map[string]float32{}),
+					MapType: getTyp(
+						reflect.TypeOf(map[int]map[string]float32{}),
+					),
+					MapValueType: getTyp(
+						reflect.TypeOf(map[string]float32{}),
+					),
+					MapCanUseAssignFaststr: false, // Non-string key type
 					Size: reflect.TypeOf(
 						map[int]map[string]float32{},
 					).Size(),
@@ -516,10 +580,13 @@ func TestAppendTypeToStack(t *testing.T) {
 					ParentFrameIndex: 0,
 				},
 				{
-					Type:             ExpectTypeMap,
-					RType:            reflect.TypeOf(map[string]float32{}),
-					Size:             reflect.TypeOf(map[string]float32{}).Size(),
-					ParentFrameIndex: 0,
+					Type:                   ExpectTypeMap,
+					RType:                  reflect.TypeOf(map[string]float32{}),
+					MapType:                getTyp(reflect.TypeOf(map[string]float32{})),
+					MapValueType:           getTyp(reflect.TypeOf(float32(0))),
+					MapCanUseAssignFaststr: true, // Size of float32 is under 128 bytes.
+					Size:                   reflect.TypeOf(map[string]float32{}).Size(),
+					ParentFrameIndex:       0,
 				},
 				{
 					Type:             ExpectTypeStr,
@@ -537,10 +604,13 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[int8]int8{},
 			ExpectStack: []stackFrame[string]{
 				{
-					Type:             ExpectTypeMap,
-					RType:            reflect.TypeOf(map[int8]int8{}),
-					Size:             reflect.TypeOf(map[int8]int8{}).Size(),
-					ParentFrameIndex: noParentFrame,
+					Type:                   ExpectTypeMap,
+					RType:                  reflect.TypeOf(map[int8]int8{}),
+					MapType:                getTyp(reflect.TypeOf(map[int8]int8{})),
+					MapValueType:           getTyp(reflect.TypeOf(int8(0))),
+					MapCanUseAssignFaststr: false,
+					Size:                   reflect.TypeOf(map[int8]int8{}).Size(),
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key
 					Type:             ExpectTypeInt8,
@@ -558,10 +628,13 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[int16]int16{},
 			ExpectStack: []stackFrame[string]{
 				{
-					Type:             ExpectTypeMap,
-					RType:            reflect.TypeOf(map[int16]int16{}),
-					Size:             reflect.TypeOf(map[int16]int16{}).Size(),
-					ParentFrameIndex: noParentFrame,
+					Type:                   ExpectTypeMap,
+					RType:                  reflect.TypeOf(map[int16]int16{}),
+					MapType:                getTyp(reflect.TypeOf(map[int16]int16{})),
+					MapValueType:           getTyp(reflect.TypeOf(int16(0))),
+					MapCanUseAssignFaststr: false,
+					Size:                   reflect.TypeOf(map[int16]int16{}).Size(),
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key
 					Type:             ExpectTypeInt16,
@@ -579,10 +652,13 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[int32]int32{},
 			ExpectStack: []stackFrame[string]{
 				{
-					Type:             ExpectTypeMap,
-					RType:            reflect.TypeOf(map[int32]int32{}),
-					Size:             reflect.TypeOf(map[int32]int32{}).Size(),
-					ParentFrameIndex: noParentFrame,
+					Type:                   ExpectTypeMap,
+					RType:                  reflect.TypeOf(map[int32]int32{}),
+					MapType:                getTyp(reflect.TypeOf(map[int32]int32{})),
+					MapValueType:           getTyp(reflect.TypeOf(int32(0))),
+					MapCanUseAssignFaststr: false,
+					Size:                   reflect.TypeOf(map[int32]int32{}).Size(),
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key
 					Type:             ExpectTypeInt32,
@@ -600,10 +676,13 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[int64]int64{},
 			ExpectStack: []stackFrame[string]{
 				{
-					Type:             ExpectTypeMap,
-					RType:            reflect.TypeOf(map[int64]int64{}),
-					Size:             reflect.TypeOf(map[int64]int64{}).Size(),
-					ParentFrameIndex: noParentFrame,
+					Type:                   ExpectTypeMap,
+					RType:                  reflect.TypeOf(map[int64]int64{}),
+					MapType:                getTyp(reflect.TypeOf(map[int64]int64{})),
+					MapValueType:           getTyp(reflect.TypeOf(int64(0))),
+					MapCanUseAssignFaststr: false,
+					Size:                   reflect.TypeOf(map[int64]int64{}).Size(),
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key
 					Type:             ExpectTypeInt64,
@@ -621,10 +700,13 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[uint]uint{},
 			ExpectStack: []stackFrame[string]{
 				{
-					Type:             ExpectTypeMap,
-					RType:            reflect.TypeOf(map[uint]uint{}),
-					Size:             reflect.TypeOf(map[uint]uint{}).Size(),
-					ParentFrameIndex: noParentFrame,
+					Type:                   ExpectTypeMap,
+					RType:                  reflect.TypeOf(map[uint]uint{}),
+					MapType:                getTyp(reflect.TypeOf(map[uint]uint{})),
+					MapValueType:           getTyp(reflect.TypeOf(uint(0))),
+					MapCanUseAssignFaststr: false,
+					Size:                   reflect.TypeOf(map[uint]uint{}).Size(),
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key
 					Type:             ExpectTypeUint,
@@ -642,10 +724,13 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[uint8]uint8{},
 			ExpectStack: []stackFrame[string]{
 				{
-					Type:             ExpectTypeMap,
-					RType:            reflect.TypeOf(map[uint8]uint8{}),
-					Size:             reflect.TypeOf(map[uint8]uint8{}).Size(),
-					ParentFrameIndex: noParentFrame,
+					Type:                   ExpectTypeMap,
+					RType:                  reflect.TypeOf(map[uint8]uint8{}),
+					MapType:                getTyp(reflect.TypeOf(map[uint8]uint8{})),
+					MapValueType:           getTyp(reflect.TypeOf(uint8(0))),
+					MapCanUseAssignFaststr: false,
+					Size:                   reflect.TypeOf(map[uint8]uint8{}).Size(),
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key
 					Type:             ExpectTypeUint8,
@@ -663,10 +748,13 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[uint16]uint16{},
 			ExpectStack: []stackFrame[string]{
 				{
-					Type:             ExpectTypeMap,
-					RType:            reflect.TypeOf(map[uint16]uint16{}),
-					Size:             reflect.TypeOf(map[uint16]uint16{}).Size(),
-					ParentFrameIndex: noParentFrame,
+					Type:                   ExpectTypeMap,
+					RType:                  reflect.TypeOf(map[uint16]uint16{}),
+					MapType:                getTyp(reflect.TypeOf(map[uint16]uint16{})),
+					MapValueType:           getTyp(reflect.TypeOf(uint16(0))),
+					MapCanUseAssignFaststr: false,
+					Size:                   reflect.TypeOf(map[uint16]uint16{}).Size(),
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key
 					Type:             ExpectTypeUint16,
@@ -684,10 +772,13 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[uint32]uint32{},
 			ExpectStack: []stackFrame[string]{
 				{
-					Type:             ExpectTypeMap,
-					RType:            reflect.TypeOf(map[uint32]uint32{}),
-					Size:             reflect.TypeOf(map[uint32]uint32{}).Size(),
-					ParentFrameIndex: noParentFrame,
+					Type:                   ExpectTypeMap,
+					RType:                  reflect.TypeOf(map[uint32]uint32{}),
+					MapType:                getTyp(reflect.TypeOf(map[uint32]uint32{})),
+					MapValueType:           getTyp(reflect.TypeOf(uint32(0))),
+					MapCanUseAssignFaststr: false,
+					Size:                   reflect.TypeOf(map[uint32]uint32{}).Size(),
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key
 					Type:             ExpectTypeUint32,
@@ -705,10 +796,13 @@ func TestAppendTypeToStack(t *testing.T) {
 			Input: map[uint64]uint64{},
 			ExpectStack: []stackFrame[string]{
 				{
-					Type:             ExpectTypeMap,
-					RType:            reflect.TypeOf(map[uint64]uint64{}),
-					Size:             reflect.TypeOf(map[uint64]uint64{}).Size(),
-					ParentFrameIndex: noParentFrame,
+					Type:                   ExpectTypeMap,
+					RType:                  reflect.TypeOf(map[uint64]uint64{}),
+					MapType:                getTyp(reflect.TypeOf(map[uint64]uint64{})),
+					MapValueType:           getTyp(reflect.TypeOf(uint64(0))),
+					MapCanUseAssignFaststr: false,
+					Size:                   reflect.TypeOf(map[uint64]uint64{}).Size(),
+					ParentFrameIndex:       noParentFrame,
 				},
 				{ // Key
 					Type:             ExpectTypeUint64,
@@ -742,11 +836,14 @@ func TestAppendTypeToStack(t *testing.T) {
 					Offset:           tpS3.Field(0).Offset,
 				},
 				{ // S3.Map
-					Type:             ExpectTypeMap,
-					Size:             reflect.TypeOf(map[string]any{}).Size(),
-					RType:            reflect.TypeOf(map[string]any{}),
-					ParentFrameIndex: 0,
-					Offset:           tpS3.Field(1).Offset,
+					Type:                   ExpectTypeMap,
+					Size:                   reflect.TypeOf(map[string]any{}).Size(),
+					RType:                  reflect.TypeOf(map[string]any{}),
+					MapType:                getTyp(reflect.TypeOf(map[string]any{})),
+					MapValueType:           getTyp(reflect.TypeOf(any(0))),
+					MapCanUseAssignFaststr: true,
+					ParentFrameIndex:       0,
+					Offset:                 tpS3.Field(1).Offset,
 				},
 				{ // Key frame
 					Type:             ExpectTypeStr,


### PR DESCRIPTION
This improves decoding of maps by about 22% by removing unnecessary runtime reflection.
The common `map[string]string` is inlined to achieve up to 50% speedups.