### PR TITLE
feat: Add type Number

### DIFF
--- a/append_type_stack.go
+++ b/append_type_stack.go
@@ -110,6 +110,9 @@ func appendTypeToStack[S []byte | string](
 				ParentFrameIndex: noParentFrame,
 			}), nil
 		case reflect.String:
+			if elem == tpNumber {
+				break
+			}
 			return append(stack, stackFrame[S]{
 				Type:             ExpectTypeSliceString,
 				Typ:              getTyp(t),
@@ -399,12 +402,21 @@ func appendTypeToStack[S []byte | string](
 			ParentFrameIndex: noParentFrame,
 		})
 	case reflect.String:
-		stack = append(stack, stackFrame[S]{
-			Type:             ExpectTypeStr,
-			Typ:              getTyp(t),
-			Size:             t.Size(),
-			ParentFrameIndex: noParentFrame,
-		})
+		if t == tpNumber {
+			stack = append(stack, stackFrame[S]{
+				Type:             ExpectTypeNumber,
+				Typ:              getTyp(t),
+				Size:             t.Size(),
+				ParentFrameIndex: noParentFrame,
+			})
+		} else {
+			stack = append(stack, stackFrame[S]{
+				Type:             ExpectTypeStr,
+				Typ:              getTyp(t),
+				Size:             t.Size(),
+				ParentFrameIndex: noParentFrame,
+			})
+		}
 	case reflect.Int:
 		stack = append(stack, stackFrame[S]{
 			Type:             ExpectTypeInt,

--- a/jscandec.go
+++ b/jscandec.go
@@ -32,18 +32,18 @@ var (
 // Number represents a JSON number literal.
 type Number string
 
-// // String returns the literal text of the number.
-// func (n Number) String() string { return string(n) }
+// String returns the literal text of the number.
+func (n Number) String() string { return string(n) }
 
-// // Float64 returns the number as a float64.
-// func (n Number) Float64() (float64, error) {
-// 	return strconv.ParseFloat(string(n), 64)
-// }
+// Float64 returns the number as a float64.
+func (n Number) Float64() (float64, error) {
+	return strconv.ParseFloat(string(n), 64)
+}
 
-// // Int64 returns the number as an int64.
-// func (n Number) Int64() (int64, error) {
-// 	return strconv.ParseInt(string(n), 10, 64)
-// }
+// Int64 returns the number as an int64.
+func (n Number) Int64() (int64, error) {
+	return strconv.ParseInt(string(n), 10, 64)
+}
 
 var tpNumber = reflect.TypeOf(Number(""))
 

--- a/jscandec_test.go
+++ b/jscandec_test.go
@@ -3700,6 +3700,7 @@ func TestDecodeNumber(t *testing.T) {
 			PrepareEncodingjson: func() any { x := json.Number(""); return &x },
 			Check: func(t *testing.T, vJscan jscandec.Number, vEncodingJson any) {
 				require.Equal(t, string(*vEncodingJson.(*json.Number)), string(vJscan))
+				require.Equal(t, expect.String(), vJscan.String())
 			},
 			Expect: expect,
 		})
@@ -3767,4 +3768,50 @@ func TestDecodeNumber(t *testing.T) {
 		jscandec.ErrorDecode{Err: jscandec.ErrUnexpectedValue, Index: 0})
 	s.testErr(t, "object", `{}`,
 		jscandec.ErrorDecode{Err: jscandec.ErrUnexpectedValue, Index: 0})
+
+	testOKInt64 := func(name, input string, expect int64) {
+		s.TestOKPrepare(t, name, input, Test[jscandec.Number]{
+			PrepareEncodingjson: func() any { x := json.Number(""); return &x },
+			Check: func(t *testing.T, vJscan jscandec.Number, vEncodingJson any) {
+				require.Equal(t, string(*vEncodingJson.(*json.Number)), string(vJscan))
+				a, err := vJscan.Int64()
+				require.NoError(t, err)
+				require.Equal(t, expect, a)
+			},
+		})
+	}
+
+	testOKInt64("int64_0", `0`, 0)
+	testOKInt64("int64_-123", `-123`, -123)
+	testOKInt64("int64_min", `-9223372036854775808`, math.MinInt64)
+	testOKInt64("int64_min", `9223372036854775807`, math.MaxInt64)
+	testOKInt64("str_int64_0", `"0"`, 0)
+	testOKInt64("str_int64_-123", `"-123"`, -123)
+	testOKInt64("str_int64_min", `"-9223372036854775808"`, math.MinInt64)
+	testOKInt64("str_int64_min", `"9223372036854775807"`, math.MaxInt64)
+
+	testOKFloat64 := func(name, input string, expect float64) {
+		s.TestOKPrepare(t, name, input, Test[jscandec.Number]{
+			PrepareEncodingjson: func() any { x := json.Number(""); return &x },
+			Check: func(t *testing.T, vJscan jscandec.Number, vEncodingJson any) {
+				require.Equal(t, string(*vEncodingJson.(*json.Number)), string(vJscan))
+				a, err := vJscan.Float64()
+				require.NoError(t, err)
+				require.Equal(t, expect, a)
+			},
+		})
+	}
+
+	testOKFloat64("float64_0", `0`, 0)
+	testOKFloat64("float64_-123", `-123`, -123)
+	testOKFloat64("float64_min", `-9223372036854775808`, math.MinInt64)
+	testOKFloat64("float64_min", `9223372036854775807`, math.MaxInt64)
+	testOKFloat64("float64_1e24", `1e24`, 1e24)
+	testOKFloat64("float64_pi", `3.14159`, 3.14159)
+	testOKFloat64("str_float64_0", `"0"`, 0)
+	testOKFloat64("str_float64_-123", `"-123"`, -123)
+	testOKFloat64("str_float64_min", `"-9223372036854775808"`, math.MinInt64)
+	testOKFloat64("str_float64_min", `"9223372036854775807"`, math.MaxInt64)
+	testOKFloat64("str_float64_1e24", `"1e24"`, 1e24)
+	testOKFloat64("str_float64_pi", `"3.14159"`, 3.14159)
 }


### PR DESCRIPTION
Add type `jscandec.Number` analogous to [`json.Number`](https://pkg.go.dev/encoding/json#Number)